### PR TITLE
implement simple support for SKIP ROM

### DIFF
--- a/src/OneWireHub.cpp
+++ b/src/OneWireHub.cpp
@@ -397,7 +397,7 @@ bool OneWireHub::recvAndProcessCmd(void)
             recv(address, 8);
             if (_error != Error::NO_ERROR)  return false;
 
-            slave_selected = 0;
+            slave_selected = nullptr;
 
             for (uint8_t i = 0; i < ONEWIRESLAVE_LIMIT; ++i)
             {
@@ -435,6 +435,21 @@ bool OneWireHub::recvAndProcessCmd(void)
 
         case 0xCC: // SKIP ROM
             slave_selected = nullptr;
+
+            for (uint8_t i = 0; i < ONEWIRESLAVE_LIMIT; ++i)
+            {
+                if (slave_list[i] != nullptr)
+                {
+                    slave_selected = slave_list[i];
+                    break;
+                }
+            }
+
+            if (slave_selected != nullptr)
+            {
+                extend_timeslot_detection = 1;
+                slave_selected->duty(this);
+            }
             return true;
 
         case 0x33: // READ ROM


### PR DESCRIPTION
The most correct implementation would be to handle the following commands by all slaves in the list. But this would require a global duty() method that calls all attached slaves. Further it would need to handle simultaneous write attempts from slaves.

Given the implemenation above, the OneWireHub would at least act correct whenever only a single slave is attached to it. The master would need to assure to only use master-write-only commands when using SKIP ROM with multiple slaves attached.
This change would allow single-slave busses to function properly and to implement OWFS simultaneous temperature/voltage reading, although the "Convert T" and "Convert V" commands are currently simply ignored by design.