### PR TITLE
implementation for DS2408

### DIFF
--- a/examples/DS2408_switch/DS2408_switch.ino
+++ b/examples/DS2408_switch/DS2408_switch.ino
@@ -52,9 +52,19 @@ void loop()
     // this part is just for debugging (USE_SERIAL_DEBUG in OneWire.h must be enabled for output)
     if (hub.getError()) hub.printError();
 
+    digitalWrite(10, ds2408.getPinState(0));
+    digitalWrite(11, ds2408.getPinState(1));
+    digitalWrite(2, ds2408.getPinState(2));
+    digitalWrite(3, ds2408.getPinState(3));
+    digitalWrite(4, ds2408.getPinState(4));
+    digitalWrite(5, ds2408.getPinState(5));
+    digitalWrite(6, ds2408.getPinState(6));
+    digitalWrite(7, ds2408.getPinState(7));
+
     // Blink triggers the state-change
     if (blinking())
     {
-
+        // this could be used to report up to eight states to 1wire master
+        //ds2408.setPinState(0, digitalRead(10));
     }
 }

--- a/src/DS2408.cpp
+++ b/src/DS2408.cpp
@@ -25,11 +25,11 @@ bool DS2408::duty(OneWireHub *hub)
         case 0xF0:      // Read PIO Registers
             targetAddress = hub->recvAndCRC16(crc);
             if (hub->getError())  return false;
-            if(targetAddress != 0x88) return false; //TODO: implement reading from specified address
+            if(targetAddress < 0x88 || targetAddress > 0x8F) return false;
             hub->recvAndCRC16(crc);
             if (hub->getError())  return false;
 
-            for (uint8_t count = 0; count < 8; ++count)
+            for (uint8_t count = targetAddress - 0x88; count < 8; ++count)
             {
                 crc = hub->sendAndCRC16(memory.registers[count], crc);
                 if (hub->getError()) return false;
@@ -48,6 +48,7 @@ bool DS2408::duty(OneWireHub *hub)
             memory.registers[DS2408_PIO_OUTPUT_REG] = data;
             memory.registers[DS2408_PIO_LOGIC_REG] = memory.registers[DS2408_PIO_OUTPUT_REG];
             hub->send(0xAA);
+            if (hub->getError())  return false;
             hub->send(memory.registers[DS2408_PIO_OUTPUT_REG]);
             break;
 

--- a/src/DS2408.cpp
+++ b/src/DS2408.cpp
@@ -2,52 +2,53 @@
 
 DS2408::DS2408(uint8_t ID1, uint8_t ID2, uint8_t ID3, uint8_t ID4, uint8_t ID5, uint8_t ID6, uint8_t ID7) : OneWireItem(ID1, ID2, ID3, ID4, ID5, ID6, ID7)
 {
-    memory.field.cmd = 0xF0;  // Cmd
-    memory.bytes[1] = 0x88;  // AdrL
-    memory.bytes[2] = 0x00;  // AdrH
-    memory.bytes[3] = 0;     // D0
-    memory.bytes[4] = 0;     // D1
-    memory.bytes[5] = 0;     // D2
-    memory.bytes[6] = 0;     // D3
-    memory.bytes[7] = 0;     // D4
-    memory.bytes[8] = 0;     // D5
-    memory.bytes[9] = 0xFF;  // D6
-    memory.bytes[10] = 0xFF; // D7
-    memory.bytes[11] = 0;  // CRCL
-    memory.bytes[12] = 0;  // CRCH
-};
-
-void DS2408::updateCRC()
-{
-    //(reinterpret_cast<sDS2408 *>(memory))->CRC = ~crc16(memory, 11);
+    memory.registers[DS2408_PIO_LOGIC_REG] = 0x41;
+    memory.registers[DS2408_PIO_OUTPUT_REG] = 0xFF;
+    memory.registers[DS2408_PIO_ACTIVITY_REG] = 0xFF;
+    memory.registers[DS2408_SEARCH_MASK_REG] = 0;
+    memory.registers[DS2408_SEARCH_SELECT_REG] = 0;
+    memory.registers[DS2408_CONTROL_STATUS_REG] = 0x88;
+    memory.registers[DS2408_RD_ABOVE_ALWAYS_FF_8E] = 0xFF;
+    memory.registers[DS2408_RD_ABOVE_ALWAYS_FF_8F] = 0xFF;
 };
 
 bool DS2408::duty(OneWireHub *hub)
 {
-    memory.field.crc = 0;
-    uint8_t cmd = hub->recvAndCRC16(memory.field.crc);
+    uint8_t targetAddress;
+    uint16_t crc = 0;
+    uint8_t cmd = hub->recvAndCRC16(crc);
+    uint8_t data;
     if (hub->getError())  return false;
 
     switch (cmd)
     {
-        // Read PIO Registers
-        case 0xF0:
-            hub->recvAndCRC16(memory.field.crc);
+        case 0xF0:      // Read PIO Registers
+            targetAddress = hub->recvAndCRC16(crc);
             if (hub->getError())  return false;
-            hub->recvAndCRC16(memory.field.crc);
+            if(targetAddress != 0x88) return false; //TODO: implement reading from specified address
+            hub->recvAndCRC16(crc);
             if (hub->getError())  return false;
 
-            for (uint8_t count = 3; count < 11; ++count)
+            for (uint8_t count = 0; count < 8; ++count)
             {
-                memory.field.crc = hub->sendAndCRC16(memory.bytes[count], memory.field.crc);
-                if (hub->getError())  return false; // directly quit when master stops, omit following data
+                crc = hub->sendAndCRC16(memory.registers[count], crc);
+                if (hub->getError()) return false;
             }
-            memory.field.crc = ~memory.field.crc; // most important step, easy to miss....
-            hub->send(memory.bytes[11]);
+            crc = ~crc; // most important step, easy to miss....
+            hub->send(reinterpret_cast<uint8_t *>(&crc)[0]);
             if (hub->getError())  return false;
-            hub->send(memory.bytes[12]);
-            if (hub->getError())  return false;
+            hub->send(reinterpret_cast<uint8_t *>(&crc)[1]);
+            break;
 
+        case 0x5A:      // Channel-Access Write
+            data = hub->recv();
+            if (hub->getError())  return false;
+            hub->recv(); //inverted data
+            if (hub->getError())  return false;
+            memory.registers[DS2408_PIO_OUTPUT_REG] = data;
+            memory.registers[DS2408_PIO_LOGIC_REG] = memory.registers[DS2408_PIO_OUTPUT_REG];
+            hub->send(0xAA);
+            hub->send(memory.registers[DS2408_PIO_OUTPUT_REG]);
             break;
 
         default:
@@ -55,4 +56,17 @@ bool DS2408::duty(OneWireHub *hub)
     };
 
     return !(hub->getError());
+};
+
+bool DS2408::getPinState(uint8_t pinNumber)
+{
+    return memory.registers[DS2408_PIO_LOGIC_REG] & 1 << pinNumber;
+};
+
+void DS2408::setPinState(uint8_t pinNumber, bool value)
+{
+    if(value)
+        memory.registers[DS2408_PIO_LOGIC_REG] |= 1 << pinNumber;
+    else
+        memory.registers[DS2408_PIO_LOGIC_REG] &= ~(1 << pinNumber);
 };

--- a/src/DS2408.h
+++ b/src/DS2408.h
@@ -6,25 +6,9 @@
 
 #include "OneWireItem.h"
 
-typedef struct
-{
-    uint8_t cmd;
-    uint8_t adrL;
-    uint8_t adrH;
-    uint8_t d0;
-    uint8_t d1;
-    uint8_t d2;
-    uint8_t d3;
-    uint8_t d4;
-    uint8_t d5;
-    uint8_t d6;
-    uint8_t d7;
-    uint16_t crc;
-} sDS2408;
 
 typedef union {
-    uint8_t bytes[13];
-    sDS2408 field;
+    uint8_t registers[8];
 } mDS2408; // overlay with memory_array
 
 
@@ -32,19 +16,17 @@ class DS2408 : public OneWireItem
 {
 private:
 
-    // Register Addresses
-    static constexpr uint8_t  DS2408_RD_BELOW_UNDEFINED  = 0x87;  // undefined data
-    static constexpr uint8_t  DS2408_PIO_LOGIC_REG       = 0x88;  // Current state
-    static constexpr uint8_t  DS2408_PIO_OUTPUT_REG      = 0x89;  // Last write, latch state register
-    static constexpr uint8_t  DS2408_PIO_ACTIVITY_REG    = 0x8A;  // State Change Activity
-    static constexpr uint8_t  DS2408_SEARCH_MASK_REG     = 0x8B;  // RW
-    static constexpr uint8_t  DS2408_SEARCH_SELECT_REG   = 0x8C;  // RW
-    static constexpr uint8_t  DS2408_CONTROL_STATUS_REG  = 0x8D;  // RW Control Register
-    static constexpr uint8_t  DS2408_RD_ABOVE_ALWAYS_FF  = 0x8E;  // these bytes give always 0xFF
+    // Register Indexes
+    static constexpr uint8_t  DS2408_PIO_LOGIC_REG          = 0; // 0x88 - Current state
+    static constexpr uint8_t  DS2408_PIO_OUTPUT_REG         = 1; // 0x89 - Last write, latch state register
+    static constexpr uint8_t  DS2408_PIO_ACTIVITY_REG       = 2; // 0x8A - State Change Activity
+    static constexpr uint8_t  DS2408_SEARCH_MASK_REG        = 3; // 0x8B - RW Conditional Search Channel Selection Mask
+    static constexpr uint8_t  DS2408_SEARCH_SELECT_REG      = 4; // 0x8C - RW Conditional Search Channel Polarity Selection
+    static constexpr uint8_t  DS2408_CONTROL_STATUS_REG     = 5; // 0x8D - RW Control Register
+    static constexpr uint8_t  DS2408_RD_ABOVE_ALWAYS_FF_8E  = 6; // 0x8E - these bytes give always 0xFF
+    static constexpr uint8_t  DS2408_RD_ABOVE_ALWAYS_FF_8F  = 7; // 0x8F - these bytes give always 0xFF
 
     mDS2408 memory;
-
-    void updateCRC(void);
 
 public:
     static constexpr uint8_t family_code = 0x29;
@@ -53,7 +35,8 @@ public:
 
     bool duty(OneWireHub *hub);
 
-
+    bool getPinState(uint8_t pinNumber);
+    void setPinState(uint8_t pinNumber, bool value);
 };
 
 #endif


### PR DESCRIPTION
Quite naive implementation for DS2408. This PR:
- fixes Read PIO Registers 0xF0 command. Previously it was pushing pin states as bytes instead of bits
- implements Channel-Access Write 0x5A command. Implementation ignores RSTZ as currently there is no possibility to set Control/Status register

The code was tested with following w1 masters:
- another Arduino running https://github.com/PaulStoffregen/OneWire
- BeagleBoneBlack running Linux 4.4.19. 1wire slave was accessed via original drivers: 
```
#set all pins to 1 (xFF)
echo -e '\xFF' |dd of=/sys/bus/w1/devices/29-010000000000/output bs=1 count=1 

#get values for all pins
dd if=/sys/bus/w1/devices/29-010000000000/state bs=1 count=1 | hexdump
```

All tests were run with original DS2408 hooked on same 1wire bus. It was used to compare commands and responses