### PR TITLE
ESP8266 calibration, still needs verifcation & cleanup

### DIFF
--- a/src/OneWireHub.cpp
+++ b/src/OneWireHub.cpp
@@ -812,6 +812,9 @@ timeOW_t OneWireHub::waitLoopsCalibrate(void)
     // repetitions the longest low-states on the bus with millis(), assume it is a OW-reset
     while (repetitions--)
     {
+#if defined(ARDUINO_ARCH_ESP8266)
+ESP.wdtFeed();
+#endif
         uint32_t time_needed = 0;
 
         // try to catch a OW-reset each time
@@ -833,6 +836,9 @@ timeOW_t OneWireHub::waitLoopsCalibrate(void)
     noInterrupts();
     while (repetitions++ < REPETITIONS)
     {
+#if defined(ARDUINO_ARCH_ESP8266)
+ESP.wdtFeed();
+#endif
         if (!waitLoopsWhilePinIs(wait_loops, true)) continue;
         const timeOW_t loops_left = waitLoopsWhilePinIs(TIMEOW_MAX, false);
         const timeOW_t loops_needed = TIMEOW_MAX - loops_left;

--- a/src/platform.h
+++ b/src/platform.h
@@ -80,7 +80,11 @@ constexpr uint8_t VALUE_IPL {0}; // instructions per loop, uncalibrated so far -
 #define DIRECT_WRITE_LOW(base, mask)    (GPOC = (mask))             //GPIO_OUT_W1TC_ADDRESS
 #define DIRECT_WRITE_HIGH(base, mask)   (GPOS = (mask))             //GPIO_OUT_W1TS_ADDRESS
 using io_reg_t = uint32_t; // define special datatype for register-access
-constexpr uint8_t VALUE_IPL {0}; // instructions per loop, uncalibrated so far - see ./examples/debug/calibrate_by_bus_timing for an explanation
+// The ESP8266 has two possible CPU frequencies
+// 80 MHz, default
+constexpr uint8_t VALUE_IPL {22}; // instructions per loop, not verified yet
+// 160 MHz
+//constexpr uint8_t VALUE_IPL {26}; // instructions per loop, not verified yet
 
 #elif defined(__SAMD21G18A__)
 #define PIN_TO_BASEREG(pin)             portModeRegister(digitalPinToPort(pin))


### PR DESCRIPTION
Some comments. 
Feeding the watchdog in the while loop is not a great idea but works. The feed command is specific to the Arduino ESP8266 implementation. I put it in a precompiler conditional so that other architectures still compile.

The ESP8266 has two possible CPU speeds, 80 and 160MHz, which resulted in two calibration values. 
Both still need confirmation with a logic analyser or oscilloscope. Automatically detecting CPU speed at compile time would also be nice.

Running the code for ~100 measurements had clear winners. Here is the serial debug output for both cases:

**esp8266 80mhz**
22	 instructions per loop
DEBUG TIMINGS for the HUB (measured in loops):
(be sure to update VALUE_IPL in src/OneWireHub_config.h first!)
value : 	275 nanoseconds per loop
reset min : 	1563
reset max : 	3490
reset tout : 	18181
presence min : 	72
presence low : 	581
pres low max : 	1745
msg hi timeout : 	54545
slot max : 	490
read1low : 	218
read std : 	72
write zero : 	109


**esp8266 160mhz**
26	 instructions per loop
DEBUG TIMINGS for the HUB (measured in loops):
(be sure to update VALUE_IPL in src/OneWireHub_config.h first!)
value : 	162 nanoseconds per loop
reset min : 	2646
reset max : 	5907
reset tout : 	30769
presence min : 	123
presence low : 	984
pres low max : 	2953
msg hi timeout : 	92307
slot max : 	830
read1low : 	369
read std : 	123
write zero : 	184
