### PR TITLE
#65 Break loop rather than return so drops through to calcCRC

### DIFF
--- a/src/DS2438.cpp
+++ b/src/DS2438.cpp
@@ -52,6 +52,15 @@ void DS2438::duty(OneWireHub * const hub)
             break; //hub->sendBit(1); // 1 is passive, so ommit it ...
 
         case 0xB4:      // Convert V
+            // Copy VDD or VAD into page zero based on REG0_MASK_AD
+            if (memory[0] & REG0_MASK_AD) {
+                memory[3] = vddVoltage[0];
+                memory[4] = vddVoltage[1];
+            } else {
+                memory[3] = vadVoltage[0];
+                memory[4] = vadVoltage[1];
+            }
+            calcCRC(0);
 
             break; //hub->sendBit(1); // 1 is passive, so ommit it ...
 
@@ -139,12 +148,31 @@ int8_t DS2438::getTemperature() const
     return memory[2];
 }
 
-
-void DS2438::setVoltage(const uint16_t voltage_10mV) // 10 bit
+void convertVoltage(uint8_t* const destination, const uint16_t voltage_10mV) // 10 bit
 {
-    memory[3] = uint8_t(voltage_10mV & 0xFF);
-    memory[4] = uint8_t((voltage_10mV >> 8) & static_cast<uint8_t>(0x03));
+    destination[0] = uint8_t(voltage_10mV & 0xFF);
+    destination[1] = uint8_t((voltage_10mV >> 8) & static_cast<uint8_t>(0x03));
+}
+
+// Deprecated method for backward compatibility - put voltage in scratchpad but also store in default (VDD).
+// This will be overwritten as a result of convert command (0xB4) with either VDD (stored here) or VAD.
+// If a system is designed such that the master knows to call 0xB4 it likely knows about REG0_MASK_AD too
+// so SetVDDVoltage SetVADVoltage should be used.
+void DS2438::setVoltage(const uint16_t voltage_10mV)
+{
+    setVDDVoltage(voltage_10mV);
+    memory[3] = vddVoltage[0];
+    memory[4] = vddVoltage[1];
     calcCRC(0);
+}
+
+void DS2438::setVDDVoltage(uint16_t voltage_10mV)
+{
+    convertVoltage(vddVoltage, voltage_10mV);
+}
+
+void DS2438::setVADVoltage(uint16_t voltage_10mV) {
+    convertVoltage(vadVoltage, voltage_10mV);
 }
 
 uint16_t DS2438::getVoltage(void) const

--- a/src/DS2438.cpp
+++ b/src/DS2438.cpp
@@ -30,7 +30,7 @@ void DS2438::duty(OneWireHub * const hub)
             for (uint8_t nByte = page<<3; nByte < (page+1)<<3; ++nByte)
             {
                 uint8_t data;
-                if (hub->recv(&data, 1)) return;
+                if (hub->recv(&data, 1)) break;
                 if ((nByte < 7) && (nByte > 0)) continue; // byte 1-6 are read only
                 memory[nByte] = data;
             }

--- a/src/DS2438.h
+++ b/src/DS2438.h
@@ -67,6 +67,10 @@ private:
     uint8_t memory[MEM_SIZE];  // this mem is the "scratchpad" in the datasheet., no EEPROM implemented
     uint8_t crc[PAGE_COUNT+1]; // keep the matching crc for each memory-page, reading can be very timesensitive
 
+    // One of the following is placed in scratchpad depending on state of REG0_MASK_AD when voltage conversion is requested
+    uint8_t vadVoltage[2];  // unsigned 10 bit
+    uint8_t vddVoltage[2];  // unsigned 10 bit
+
     void calcCRC(uint8_t page);
 
 public:
@@ -86,7 +90,10 @@ public:
     void     setTemperature(int8_t temp_degC);
     int8_t   getTemperature(void) const;
 
-    void     setVoltage(uint16_t voltage_10mV); // unsigned 10 bit
+    // setVoltage should be considered deprecated in favour of setVDDVoltage (default) & setVADVoltage
+    void     setVoltage(uint16_t voltage_10mV);     // unsigned 10 bit
+    void     setVDDVoltage(uint16_t voltage_10mV);  // unsigned 10 bit
+    void     setVADVoltage(uint16_t voltage_10mV);  // unsigned 10 bit
     uint16_t getVoltage(void) const;
 
     void     setCurrent(int16_t value);  // signed 11 bit

--- a/src/OneWireHub.cpp
+++ b/src/OneWireHub.cpp
@@ -352,8 +352,6 @@ void OneWireHub::searchIDTree(void)
     uint8_t active_slave    = idTree[trigger_pos].slave_selected;
     uint8_t trigger_bit     = idTree[trigger_pos].id_position;
 
-    noInterrupts();
-
     while (position_IDBit < 64)
     {
         // if junction is reached, act different
@@ -399,8 +397,6 @@ void OneWireHub::searchIDTree(void)
         position_IDBit++;
     }
 
-    interrupts();
-
     slave_selected = slave_list[active_slave];
 }
 
@@ -419,7 +415,9 @@ bool OneWireHub::recvAndProcessCmd(void)
         case 0xF0: // Search rom
 
             slave_selected = nullptr;
+            noInterrupts();
             searchIDTree();
+            interrupts();
             return false; // always trigger a re-init after searchIDTree
 
         case 0x69: // overdrive MATCH ROM


### PR DESCRIPTION
Using a Loxone master, this change makes the sensor reliably appear. Before the change, sensor could be detected with a scan but never read. Fixes #65.