### PR TITLE
Add MegaCoreX support

### DIFF
--- a/src/OneWireHub.h
+++ b/src/OneWireHub.h
@@ -8,9 +8,12 @@ constexpr timeOW_t timeOW_max = 4294967295; // will arduino-gcc ever offer some 
 
 constexpr timeOW_t operator "" _us(const unsigned long long int time_us) // user defined literal used in config
 {
-// ARCH 103 is xmega3: ATmega480x,ATmega320x etc. microsecondsToClockCycles in implemented as not constexpr
+/* ARCH 103 is xmega3: ATmega480x,ATmega320x etc. 
+ * microsecondsToClockCycles in megacorex implemented differently so expression can not
+ * be evaluated at compile time. This might change some time!
+ */
 #if __AVR_ARCH__ == 103 
-	return timeOW_t(time_us * ( F_CPU /1000000UL ) / VALUE_IPL);
+    return timeOW_t(time_us * ( F_CPU /1000000UL ) / VALUE_IPL);
 #else
     return timeOW_t(time_us * microsecondsToClockCycles(1) / VALUE_IPL); // note: microsecondsToClockCycles == speed in MHz....
     // TODO: overflow detection would be nice, but literals are allowed with return-only, not solvable ATM
@@ -21,9 +24,12 @@ constexpr timeOW_t operator "" _us(const unsigned long long int time_us) // user
 // same FN, but not as literal
 constexpr timeOW_t timeUsToLoops(const uint16_t time_us)
 {
-// ARCH 103 is xmega3: ATmega480x,ATmega320x etc. microsecondsToClockCycles in implemented as not constexpr
+/* ARCH 103 is xmega3: ATmega480x,ATmega320x etc. 
+ * microsecondsToClockCycles in megacorex implemented differently so expression can not
+ * be evaluated at compile time. This might change some time!
+ */
 #if __AVR_ARCH__ == 103 
-	return (time_us * ( F_CPU /1000000UL ) / VALUE_IPL);
+    return (time_us * ( F_CPU /1000000UL ) / VALUE_IPL);
 #else
     return (time_us * microsecondsToClockCycles(1) / VALUE_IPL); // note: microsecondsToClockCycles == speed in MHz....
 #endif

--- a/src/OneWireHub.h
+++ b/src/OneWireHub.h
@@ -8,15 +8,25 @@ constexpr timeOW_t timeOW_max = 4294967295; // will arduino-gcc ever offer some 
 
 constexpr timeOW_t operator "" _us(const unsigned long long int time_us) // user defined literal used in config
 {
+// ARCH 103 is xmega3: ATmega480x,ATmega320x etc. microsecondsToClockCycles in implemented as not constexpr
+#if __AVR_ARCH__ == 103 
+	return timeOW_t(time_us * ( F_CPU /1000000UL ) / VALUE_IPL);
+#else
     return timeOW_t(time_us * microsecondsToClockCycles(1) / VALUE_IPL); // note: microsecondsToClockCycles == speed in MHz....
     // TODO: overflow detection would be nice, but literals are allowed with return-only, not solvable ATM
+#endif
 }
 
 
 // same FN, but not as literal
 constexpr timeOW_t timeUsToLoops(const uint16_t time_us)
 {
+// ARCH 103 is xmega3: ATmega480x,ATmega320x etc. microsecondsToClockCycles in implemented as not constexpr
+#if __AVR_ARCH__ == 103 
+	return (time_us * ( F_CPU /1000000UL ) / VALUE_IPL);
+#else
     return (time_us * microsecondsToClockCycles(1) / VALUE_IPL); // note: microsecondsToClockCycles == speed in MHz....
+#endif
 }
 
 #include "OneWireHub_config.h" // outsource configfile

--- a/src/platform.h
+++ b/src/platform.h
@@ -15,7 +15,19 @@
 #define ONEWIRE_GCC_VERSION 0
 #endif
 
-#if defined(__AVR__) /* arduino (all with atmega, atiny) */
+#if defined(__AVR_XMEGA__)
+
+#define PIN_TO_BASEREG(pin)             (portModeRegister(digitalPinToPort(pin)))
+#define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))
+#define DIRECT_READ(base, mask)         (((*((base)+8)) & (mask)) ? 1 : 0)
+#define DIRECT_MODE_INPUT(base, mask)   ((*((base))) &= ~(mask))
+#define DIRECT_MODE_OUTPUT(base, mask)  ((*((base))) |= (mask))
+#define DIRECT_WRITE_LOW(base, mask)    ((*((base)+4)) &= ~(mask))
+#define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+4)) |= (mask))	
+using io_reg_t = uint8_t; // define special datatype for register-access
+constexpr uint8_t VALUE_IPL {13}; // instructions per loop, compare 0 takes 11, compare 1 takes 13 cycles
+
+#elif defined(__AVR__) /* arduino (all with atmega, atiny) */
 
 #define PIN_TO_BASEREG(pin)             (portInputRegister(digitalPinToPort(pin)))
 #define PIN_TO_BITMASK(pin)             (digitalPinToBitMask(pin))


### PR DESCRIPTION
Add MegaCoreX (official megaavr should work too but not tested). But MegaCoreX supports all new atmega devices so I chose that one.
Tested on ATmega4808 and ATmega4809.
It is mainly because of the new microsecondsToClockCycles implementation of megacorex and megaavr support and the Port Registers differ from atmega/tiny. This might change in the future