### PR TITLE
Added non-multidrop support for slaves.

### DIFF
--- a/src/DS2434.cpp
+++ b/src/DS2434.cpp
@@ -2,6 +2,10 @@
 
 DS2434::DS2434(uint8_t ID1, uint8_t ID2, uint8_t ID3, uint8_t ID4, uint8_t ID5, uint8_t ID6, uint8_t ID7) : OneWireItem(ID1, ID2, ID3, ID4, ID5, ID6, ID7)
 {
+    // The DS2434 is NOT compatible with multidrop.
+    // It can be the only one of the bus
+    MULTIDROP = false; 
+    
     clearMemory();
     clearScratchpad();
     // TODO: ID-Order is just an assumption
@@ -9,6 +13,7 @@ DS2434::DS2434(uint8_t ID1, uint8_t ID2, uint8_t ID3, uint8_t ID4, uint8_t ID5, 
     scratchpad[81] = ID2;
 }
 
+// As this device is not multidrop, it needs to handle ALL commands from the master
 void DS2434::duty(OneWireHub * const hub)
 {
     uint8_t start_byte, cmd, data;

--- a/src/OneWireHub.cpp
+++ b/src/OneWireHub.cpp
@@ -407,6 +407,7 @@ bool OneWireHub::recvAndProcessCmd(void)
     if(slave_count == 1){
 
         slave_selected = slave_list[getIndexOfNextSensorInList()];
+        // TODO: this might be expensive for weak uC and OW in Overdrive -> look into optimizations (i.e. preselect when only one device present?)
 
         if( slave_selected->MULTIDROP == false ){
             slave_selected->duty(this);

--- a/src/OneWireHub.cpp
+++ b/src/OneWireHub.cpp
@@ -402,6 +402,18 @@ void OneWireHub::searchIDTree(void)
 
 bool OneWireHub::recvAndProcessCmd(void)
 {
+
+    // If the only slave is not multidrop compatible, pass all data handling to the slave
+    if(slave_count == 1){
+
+        slave_selected = slave_list[getIndexOfNextSensorInList()];
+
+        if( slave_selected->MULTIDROP == false ){
+            slave_selected->duty(this);
+            return (_error != Error::NO_ERROR);
+        }        
+    }
+
     uint8_t address[8], cmd;
     bool    flag = false;
 

--- a/src/OneWireItem.h
+++ b/src/OneWireItem.h
@@ -27,6 +27,10 @@ public:
     OneWireItem& operator=(const OneWireItem& owItem) = delete;  // disallow copy assignment
     OneWireItem& operator=(OneWireItem&& owItem) = delete;       // disallow move assignment
 
+    // Specify if the device can be used on a bus with other 1-wire devices
+    // If FALSE all commands will be passed through directly to the duty() call of the device
+    bool MULTIDROP { true };
+    
     uint8_t ID[8];
 
     void sendID(OneWireHub * hub) const;

--- a/src/OneWireItem.h
+++ b/src/OneWireItem.h
@@ -29,7 +29,7 @@ public:
 
     // Specify if the device can be used on a bus with other 1-wire devices
     // If FALSE all commands will be passed through directly to the duty() call of the device
-    bool MULTIDROP { true };
+    bool MULTIDROP { true }; // TODO: should be lowercase, as it is no constant (yet)
     
     uint8_t ID[8];
 


### PR DESCRIPTION
Some slaves are required to be the only ones on the bus, such as the DS2434. This change allows a device to specify if it is multidrop compatible. If it is not, all commands are forwarded to the salve as the master will not perform any search or selection functions.

I added a property in the OneWireItem header with a default value, so there shouldn't be any code changes needed for the devices already implemented.