### PR TITLE
701dev

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "ostream": "cpp",
+        "locale": "cpp"
+    }
+}

--- a/examples/DS2434_IBM701c/DS2434_IBM701c.ino
+++ b/examples/DS2434_IBM701c/DS2434_IBM701c.ino
@@ -28,8 +28,7 @@ void setup()
     ds2434.writeMemory(reinterpret_cast<const uint8_t *>(mem2),sizeof(mem2),0x20);
 
     ds2434.lockNV1();
-    ds2434.setID(0xCABDu);
-    ds2434.setBatteryCounter(1234u);
+    ds2434.setBatteryCounter(0x0101u);
 }
 
 void loop()

--- a/src/DS2434.cpp
+++ b/src/DS2434.cpp
@@ -146,18 +146,18 @@ void DS2434::clearScratchpad(void)
     memset(scratchpad, static_cast<uint8_t>(0xFF), SCRATCHPAD_SIZE);
 }
 
-bool DS2434::writeMemory(const uint8_t* const source, const uint16_t length, const uint16_t position)
+bool DS2434::writeMemory(const uint8_t* const source, const uint8_t length, const uint8_t position)
 {
     if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    const uint8_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
     memcpy(&memory[position],source,_length);
     return true;
 }
 
-bool DS2434::readMemory(uint8_t* const destination, const uint16_t length, const uint16_t position) const
+bool DS2434::readMemory(uint8_t* const destination, const uint8_t length, const uint8_t position) const
 {
     if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    const uint8_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
     memcpy(destination,&memory[position],_length);
     return (_length==length);
 }

--- a/src/DS2434.cpp
+++ b/src/DS2434.cpp
@@ -2,21 +2,19 @@
 
 DS2434::DS2434(uint8_t ID1, uint8_t ID2, uint8_t ID3, uint8_t ID4, uint8_t ID5, uint8_t ID6, uint8_t ID7) : OneWireItem(ID1, ID2, ID3, ID4, ID5, ID6, ID7)
 {
-    // The DS2434 is NOT compatible with multidrop.
-    // It can be the only one of the bus
-    MULTIDROP = false; 
-    
+    // disable bus-features:
+    // The DS2434 is NOT compatible with multidrop -> only one device on bus!
+    skip_multidrop = true;
+
     clearMemory();
     clearScratchpad();
-    // TODO: ID-Order is just an assumption
-    scratchpad[80] = ID1;
-    scratchpad[81] = ID2;
 }
 
 // As this device is not multidrop, it needs to handle ALL commands from the master
 void DS2434::duty(OneWireHub * const hub)
 {
     uint8_t start_byte, cmd, data;
+    uint32_t time_now;
     if (hub->recv(&cmd))  return;
 
     switch (cmd)
@@ -47,11 +45,13 @@ void DS2434::duty(OneWireHub * const hub)
         if (memory[0x62] & 0b100u) return; // check LOCK-Status
         writeMemory(&scratchpad[PAGE1_ADDR], PAGE_SIZE, PAGE1_ADDR);
         // NOTE: OP occupies real NV for ~ 10 ms (NVB-Bit)
+        timer_nvwr = millis() + DURATION_NVWR_ms;
         break;
 
     case 0x25:      // copy scratchpad SP2 to NV2
         writeMemory(&scratchpad[PAGE2_ADDR], PAGE_SIZE, PAGE2_ADDR);
         // NOTE: OP occupies real NV for ~ 10 ms (NVB-Bit)
+        timer_nvwr = millis() + DURATION_NVWR_ms;
         break;
 
     case 0x28:      // copy scratchpad SP3 to SRAM
@@ -65,50 +65,70 @@ void DS2434::duty(OneWireHub * const hub)
     case 0x77:      // Recall Memory, NV2 to SP2
         readMemory(&scratchpad[PAGE2_ADDR], PAGE_SIZE, PAGE2_ADDR);
         // NOTE: OP occupies real NV for ~ 10 ms (NVB-Bit)
+        timer_nvwr = millis() + DURATION_NVWR_ms;
         break;
 
     case 0x7A:      // Recall Memory, SRAM to SP3
         readMemory(&scratchpad[PAGE3_ADDR], PAGE_SIZE, PAGE3_ADDR);
         // NOTE: OP occupies real NV for ~ 10 ms (NVB-Bit)
+        timer_nvwr = millis() + DURATION_NVWR_ms;
         break;
 
     case 0x43:      // lock NV1
         lockNV1();
         // NOTE: OP occupies real NV for ~ 10 ms (NVB-Bit)
+        timer_nvwr = millis() + DURATION_NVWR_ms;
         break;
     case 0x44:      // unlock NV1
         unlockNV1();
         // NOTE: OP occupies real NV for ~ 10 ms (NVB-Bit)
+        timer_nvwr = millis() + DURATION_NVWR_ms;
         break;
 
     case 0xD2:      // trigger temperature-reading
-        scratchpad[0x62] |= 0b1u;
+        request_temp = true;
+        timer_temp = millis() + DURATION_TEMP_ms;
         break;
 
     case 0xB2:      // read Page 4 and 5
         if (hub->recv(&start_byte))  return;
         if (start_byte < PAGE4_ADDR) return; // when out of limits
         if (start_byte >= PAGE6_ADDR) return;
+
+        // update status byte, TODO: done here because laptop waits -> check duration
+        time_now = millis();
+        if (time_now >= timer_nvwr)     memory[0x62] &= ~0b10u; // erase busy-flag
+        else                            memory[0x62] |= 0b10u; // set busy-flag
+        if (time_now >= timer_temp)     memory[0x62] &= ~0b1u; // erase busy-flag
+        else                            memory[0x62] |= 0b1u; // set busy-flag
+
         for (uint8_t nByte = start_byte; nByte < PAGE6_ADDR; ++nByte)
         {
-            if (hub->recv(&data, 1)) return;
-            scratchpad[nByte] = data;
+            if (hub->send(&memory[nByte], 1)) return;
         }
         break;
 
     case 0xB5:      // increment Cycle
-        if (++scratchpad[83] == 0u)
+        if (++memory[0x83] == 0u)
         {
             // after overflow of LSB
-            scratchpad[82]++;
+            memory[0x82]++;
         }
         // NOTE: OP occupies real NV for ~ 10 ms (NVB-Bit)
+        timer_nvwr = millis() + DURATION_NVWR_ms;
         break;
 
     case 0xB8:      // reset Cycle
-        scratchpad[82] = 0u;
-        scratchpad[83] = 0u;
+        memory[0x82] = 0u;
+        memory[0x83] = 0u;
         // NOTE: OP occupies real NV for ~ 10 ms (NVB-Bit)
+        timer_nvwr = millis() + DURATION_NVWR_ms;
+        break;
+
+    case 0x8E:      // secret command just to avoid triggering an error
+        break;
+    case 0x84:      // second secret command
+        if (hub->recv(&data))  return;
         break;
 
     default:
@@ -148,38 +168,38 @@ void DS2434::setTemperature(const int8_t temp_degC)
 
     if (value > 126) value = 126;
     if (value < -40) value = -40;
-    memory[61] = value;
+    memory[0x61] = value;
 
     if (value < 0) value = 0;
     uint8_t uvalue = static_cast<uint8_t>(value);
 
-    memory[60] = uvalue << 1u;
+    memory[0x60] = uvalue << 1u;
 
     // reset request
-    scratchpad[0x62] &= ~0b1u;
+    request_temp = false;
 }
 
 bool DS2434::getTemperatureRequest() const
 {
-    return (scratchpad[0x62] & 0b1u);
+    return (request_temp);
 }
 
 void DS2434::lockNV1()
 {
-    scratchpad[0x62] |= 0b100u;
+    memory[0x62] |= 0b100u;
 }
 
 void DS2434::unlockNV1()
 {
-    scratchpad[0x62] &= ~0b100u;
+    memory[0x62] &= ~0b100u;
 }
 
 void DS2434::setBatteryCounter(uint16_t value)
 {
-    *((uint16_t *) &scratchpad[82]) = value;
+    *((uint16_t *) &memory[0x82]) = value;
 }
 
 void DS2434::setID(uint16_t value)
 {
-    *((uint16_t *) &scratchpad[80]) = value;
+    *((uint16_t *) &memory[0x80]) = value;
 }

--- a/src/DS2434.h
+++ b/src/DS2434.h
@@ -48,7 +48,7 @@ private:
     static constexpr uint8_t  PAGE_SIZE          { 32 };
     static constexpr uint8_t  PAGE_COUNT         { 5 };
 
-    static constexpr uint8_t  MEM_SIZE           { PAGE_COUNT * PAGE_SIZE };
+    static constexpr uint8_t  MEM_SIZE           { 132 };
     static constexpr uint8_t  SCRATCHPAD_SIZE    { 3 * PAGE_SIZE };
 
     static constexpr uint32_t DURATION_TEMP_ms   { 230 };
@@ -72,8 +72,8 @@ public:
 
     void    clearMemory(void);
 
-    bool    writeMemory(const uint8_t* source, uint16_t length, uint16_t position = 0);
-    bool    readMemory(uint8_t* destination, uint16_t length, uint16_t position = 0) const;
+    bool    writeMemory(const uint8_t* source, uint8_t length, uint8_t position = 0);
+    bool    readMemory(uint8_t* destination, uint8_t length, uint8_t position = 0) const;
 
     void     setTemperature(int8_t temp_degC); // can vary from -40 to 127 degC
     bool     getTemperatureRequest(void) const;

--- a/src/DS2434.h
+++ b/src/DS2434.h
@@ -48,8 +48,14 @@ private:
     static constexpr uint8_t  PAGE_SIZE          { 32 };
     static constexpr uint8_t  PAGE_COUNT         { 5 };
 
-    static constexpr uint8_t  MEM_SIZE           { 3 * PAGE_SIZE };
-    static constexpr uint8_t  SCRATCHPAD_SIZE    { PAGE_COUNT * PAGE_SIZE };
+    static constexpr uint8_t  MEM_SIZE           { PAGE_COUNT * PAGE_SIZE };
+    static constexpr uint8_t  SCRATCHPAD_SIZE    { 3 * PAGE_SIZE };
+
+    static constexpr uint32_t DURATION_TEMP_ms   { 230 };
+    static constexpr uint32_t DURATION_NVWR_ms   { 10 };
+    uint32_t timer_temp = 0u;
+    uint32_t timer_nvwr = 0u;
+    bool     request_temp = false;
 
     uint8_t  memory[MEM_SIZE];
     uint8_t  scratchpad[SCRATCHPAD_SIZE];
@@ -58,7 +64,7 @@ private:
 
 public:
 
-    static constexpr uint8_t family_code        { 0x53 }; // TODO: 1B seems to be right
+    static constexpr uint8_t family_code        { 0x53 }; // TODO: 1B seems to be right (for ds2436)
 
     DS2434(uint8_t ID1, uint8_t ID2, uint8_t ID3, uint8_t ID4, uint8_t ID5, uint8_t ID6, uint8_t ID7);
 

--- a/src/OneWireHub.cpp
+++ b/src/OneWireHub.cpp
@@ -404,12 +404,13 @@ bool OneWireHub::recvAndProcessCmd(void)
 {
 
     // If the only slave is not multidrop compatible, pass all data handling to the slave
-    if(slave_count == 1){
+    if(slave_count == 1u){
 
         slave_selected = slave_list[getIndexOfNextSensorInList()];
-        // TODO: this might be expensive for weak uC and OW in Overdrive -> look into optimizations (i.e. preselect when only one device present?)
+        // TODO: this might be expensive for weak uC and OW in Overdrive and only one device emulated
+        //  -> look into optimizations (i.e. preselect when only one device present?)
 
-        if( slave_selected->MULTIDROP == false ){
+        if( slave_selected->skip_multidrop ){
             slave_selected->duty(this);
             return false;
         }        
@@ -431,8 +432,13 @@ bool OneWireHub::recvAndProcessCmd(void)
             noInterrupts();
             searchIDTree();
             interrupts();
-            // slave_selected->duty(this);
-            // TODO: some ICs like DS2430 allow going for duty() right after search
+
+            // most ICs allow going for duty() right after search
+            if ((_error == Error::NO_ERROR) && (slave_selected != nullptr) && slave_selected->fast_search_rom)
+            {
+                slave_selected->duty(this);
+            }
+
             return false; // always trigger a re-init after searchIDTree
 
         case 0x69: // overdrive MATCH ROM
@@ -520,6 +526,12 @@ bool OneWireHub::recvAndProcessCmd(void)
             if (slave_selected != nullptr)
             {
                 slave_selected->sendID(this);
+
+                // most ICs allow to go to duty() without reset
+                if ((_error == Error::NO_ERROR) && slave_selected->fast_read_rom)
+                {
+                    slave_selected->duty(this);
+                }
             }
             return false;
 

--- a/src/OneWireHub.cpp
+++ b/src/OneWireHub.cpp
@@ -411,7 +411,7 @@ bool OneWireHub::recvAndProcessCmd(void)
 
         if( slave_selected->MULTIDROP == false ){
             slave_selected->duty(this);
-            return (_error != Error::NO_ERROR);
+            return false;
         }        
     }
 

--- a/src/OneWireItem.h
+++ b/src/OneWireItem.h
@@ -27,10 +27,16 @@ public:
     OneWireItem& operator=(const OneWireItem& owItem) = delete;  // disallow copy assignment
     OneWireItem& operator=(OneWireItem&& owItem) = delete;       // disallow move assignment
 
+    // DEFAULT BUS-FEATURES:
     // Specify if the device can be used on a bus with other 1-wire devices
     // If FALSE all commands will be passed through directly to the duty() call of the device
-    bool MULTIDROP { true }; // TODO: should be lowercase, as it is no constant (yet)
-    
+    // NOTE: there can be only one device on the bus (beside the controller)
+    bool skip_multidrop            { false };
+    // skip reboot after a search-rom command -> feature normal, except ds2401 & ds18b20
+    bool fast_search_rom           { true };
+    // skip reboot after a read-rom command -> feature normal, except ds2401
+    bool fast_read_rom             { true };
+
     uint8_t ID[8];
 
     void sendID(OneWireHub * hub) const;


### PR DESCRIPTION
- Fixed one issue where the non-multidrop code resulted in a double reset after some read commands. 
- Reading the spec, it seems that the scratch pad is only for pages 1 through 3, and pages 4 and 5, where a lot of the status registers sit, are always accessed via memory. I'm not sure if that's right, but the commands that copy the scratchpad in and out of memory only seem to cover pages 1 through 3.

With these changes, the 701c laptop now recognizes the Arduino as a real DS2434 and allows it to charge! Compiling and loading onto an Attiny is incredibly unstable still - mixed results with the laptop recognizing - or not - and sometimes in odd charging states.