### PR TITLE
Edit scratchpad registers in Setup() or Loop(). See reference: orgua#124

### DIFF
--- a/src/DS18B20.cpp
+++ b/src/DS18B20.cpp
@@ -20,6 +20,25 @@ DS18B20::DS18B20(uint8_t ID1, uint8_t ID2, uint8_t ID3, uint8_t ID4, uint8_t ID5
     fast_search_rom = false;
 }
 
+DS18B20::setScratchpad(uint8_t ID1, uint8_t ID2, uint8_t ID3, uint8_t ID4, uint8_t ID5, uint8_t ID6, uint8_t ID7)
+{
+    scratchpad[0] = 0xA0; // TLSB --> 10 degC as std
+    scratchpad[1] = 0x00; // TMSB
+    scratchpad[2] = 0x4B; // THRE --> Trigger register TH
+    scratchpad[3] = 0x46; // TLRE --> TLow
+    scratchpad[4] = 0x7F; // Conf
+    // = 0 R1 R0 1 1 1 1 1 --> R=0 9bit .... R=3 12bit
+    scratchpad[5] = 0xFF; // 0xFF
+    scratchpad[6] = 0x00; // Reset
+    scratchpad[7] = 0x10; // 0x10
+    updateCRC(); // update scratchpad[8]
+
+    ds18s20_mode = (ID1 == 0x10); // different tempRegister
+
+    // disable bus-features:
+    fast_search_rom = false;
+}
+
 void DS18B20::updateCRC()
 {
     scratchpad[8] = crc8(scratchpad, 8);

--- a/src/DS18B20.h
+++ b/src/DS18B20.h
@@ -25,6 +25,8 @@ public:
     static constexpr uint8_t family_code                { 0x28 }; // is compatible to ds1822 (0x22) and ds18S20 (0x10)
 
     DS18B20(uint8_t ID1, uint8_t ID2, uint8_t ID3, uint8_t ID4, uint8_t ID5, uint8_t ID6, uint8_t ID7);
+    
+    void setScratchpad(uint8_t ID1, uint8_t ID2, uint8_t ID3, uint8_t ID4, uint8_t ID5, uint8_t ID6, uint8_t ID7);
 
     void duty(OneWireHub * hub) final;
 


### PR DESCRIPTION

I duplicated the constructor as a function, I hope it's enough to update the scratchpad data.

https://github.com/orgua/OneWireHub/issues/124