### PR TITLE
Fix OneWireHub to work with ESP32

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# MODIFIED VERSION OF ONEWIREHUB WITH ESP32 SUPPORT FROM KILDOOM
+# МОДИФИЦИРОВАННАЯ ВЕРСИЯ ONEWIREHUB С ПОДДЕРЖКОЙ ESP32 ОТ КИЛДУОМА
+
 # OneWireHub
 
 The OneWireHub is a sleek Arduino compatible (and many more platforms) library to emulate OneWire-Periphery with support for various devices & sensors. The motivation is to offer a shared code base for all OneWire-Periphery-Devices. With a small overhead one µC can emulate up to 32 ICs simultaneously.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# MODIFIED VERSION OF ONEWIREHUB WITH ESP32 SUPPORT FROM KILDOOM
-# МОДИФИЦИРОВАННАЯ ВЕРСИЯ ONEWIREHUB С ПОДДЕРЖКОЙ ESP32 ОТ КИЛДУМА
-
 # OneWireHub
 
 The OneWireHub is a sleek Arduino compatible (and many more platforms) library to emulate OneWire-Periphery with support for various devices & sensors. The motivation is to offer a shared code base for all OneWire-Periphery-Devices. With a small overhead one µC can emulate up to 32 ICs simultaneously.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MODIFIED VERSION OF ONEWIREHUB WITH ESP32 SUPPORT FROM KILDOOM
-# МОДИФИЦИРОВАННАЯ ВЕРСИЯ ONEWIREHUB С ПОДДЕРЖКОЙ ESP32 ОТ КИЛДУОМА
+# МОДИФИЦИРОВАННАЯ ВЕРСИЯ ONEWIREHUB С ПОДДЕРЖКОЙ ESP32 ОТ КИЛДУМА
 
 # OneWireHub
 

--- a/src/DS2408.cpp
+++ b/src/DS2408.cpp
@@ -20,13 +20,13 @@ void DS2408::duty(OneWireHub *const hub)
         case 0xF0: // Read PIO Registers
 
             if (hub->recv(&reg_TA, 1, crc)) return;
-            if ((reg_TA < REG_OFFSET) || (reg_TA >= REG_OFFSET + MEM_SIZE)) return;
+            if ((reg_TA < REG_OFFSET) || (reg_TA >= REG_OFFSET + MEMORY_SIZE)) return;
             if (hub->recv(&data, 1, crc)) return; // seconds part of reg_TA, should be zero
             if (data != 0) return;
 
             {
                 const uint8_t start  = (reg_TA - REG_OFFSET);
-                const uint8_t length = MEM_SIZE - start;
+                const uint8_t length = MEMORY_SIZE - start;
                 if (hub->send(&memory[start], length, crc)) return;
             }
 

--- a/src/DS2408.h
+++ b/src/DS2408.h
@@ -10,7 +10,7 @@
 class DS2408 : public OneWireItem
 {
 private:
-    static constexpr uint8_t MEM_SIZE{8};
+    static constexpr uint8_t MEMORY_SIZE{8};
 
     // Register Indexes
     static constexpr uint8_t REG_OFFSET{0x88};
@@ -25,7 +25,7 @@ private:
     static constexpr uint8_t REG_RD_ABOVE_ALWAYS_FF_8E{6}; // 0x8E - these bytes give always 0xFF
     static constexpr uint8_t REG_RD_ABOVE_ALWAYS_FF_8F{7}; // 0x8F - these bytes give always 0xFF
 
-    uint8_t memory[MEM_SIZE];
+    uint8_t memory[MEMORY_SIZE];
 
 public:
     static constexpr uint8_t family_code{0x29};

--- a/src/DS2423.cpp
+++ b/src/DS2423.cpp
@@ -146,15 +146,15 @@ void DS2423::duty(OneWireHub *const hub)
 }
 
 
-void DS2423::clearMemory(void) { memset(memory, static_cast<uint8_t>(0x00), MEM_SIZE); }
+void DS2423::clearMemory(void) { memset(memory, static_cast<uint8_t>(0x00), MEMORY_SIZE); }
 
 void DS2423::clearScratchpad(void) { memset(scratchpad, static_cast<uint8_t>(0x00), PAGE_SIZE); }
 
 bool DS2423::writeMemory(const uint8_t *const source, const uint16_t length,
                          const uint16_t position)
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(&memory[position], source, _length);
 
     const uint8_t page_start = uint8_t(position >> 5);
@@ -173,8 +173,8 @@ bool DS2423::writeMemory(const uint8_t *const source, const uint16_t length,
 bool DS2423::readMemory(uint8_t *const destination, const uint16_t length,
                         const uint16_t position) const
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(destination, &memory[position], _length);
     return (_length == length);
 }

--- a/src/DS2423.h
+++ b/src/DS2423.h
@@ -10,10 +10,10 @@
 class DS2423 : public OneWireItem
 {
 private:
-    static constexpr uint16_t MEM_SIZE{512};
+    static constexpr uint16_t MEMORY_SIZE{512};
 
     static constexpr uint8_t  PAGE_SIZE{32};
-    static constexpr uint16_t PAGE_COUNT{MEM_SIZE / PAGE_SIZE};
+    static constexpr uint16_t PAGE_COUNT{MEMORY_SIZE / PAGE_SIZE};
     static constexpr uint8_t  PAGE_MASK{0b00011111};
 
     static constexpr uint8_t COUNTER_COUNT{4};
@@ -28,7 +28,7 @@ private:
     static constexpr uint16_t REG_TA_MASK{
             0x01FF}; // Addresses will be stripped of the highest 7 bytes
 
-    uint8_t  memory[MEM_SIZE]; // 4kbit max storage
+    uint8_t  memory[MEMORY_SIZE]; // 4kbit max storage
     uint8_t  scratchpad[PAGE_SIZE];
     uint32_t memcounter[COUNTER_COUNT];
 

--- a/src/DS2430.cpp
+++ b/src/DS2430.cpp
@@ -117,15 +117,15 @@ bool DS2430::writeMemory(const uint8_t *const source, const uint8_t length, cons
 bool DS2430::readMemory(uint8_t *const destination, const uint16_t length,
                         const uint16_t position) const
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(destination, &memory[position], _length);
     return (_length == length);
 }
 
 bool DS2430::syncScratchpad()
 {
-    uint8_t length = (MEM_SIZE > SCRATCHPAD_SIZE) ? SCRATCHPAD_SIZE : MEM_SIZE;
+    uint8_t length = (MEMORY_SIZE > SCRATCHPAD_SIZE) ? SCRATCHPAD_SIZE : MEMORY_SIZE;
     memcpy(scratchpad, memory, length);
     return true;
 }

--- a/src/DS2430.h
+++ b/src/DS2430.h
@@ -9,7 +9,7 @@
 class DS2430 : public OneWireItem
 {
 private:
-    static constexpr uint8_t MEM_SIZE{32 + 8};
+    static constexpr uint8_t MEMORY_SIZE{32 + 8};
 
     static constexpr uint8_t SCRATCHPAD_SIZE{32 + 8};
 
@@ -20,7 +20,7 @@ private:
     static constexpr uint8_t SCRATCHPAD2_SIZE{8};
     static constexpr uint8_t SCRATCHPAD2_MASK{0b00000111};
 
-    uint8_t memory[MEM_SIZE];
+    uint8_t memory[MEMORY_SIZE];
 
     uint8_t scratchpad[SCRATCHPAD_SIZE];
 

--- a/src/DS2431.cpp
+++ b/src/DS2431.cpp
@@ -128,8 +128,8 @@ void DS2431::duty(OneWireHub *const hub)
         case 0xF0: // READ MEMORY COMMAND
 
             if (hub->recv(reinterpret_cast<uint8_t *>(&reg_TA), 2)) return;
-            if (reg_TA >= MEM_SIZE) return;
-            if (hub->send(&memory[reg_TA], MEM_SIZE - uint8_t(reg_TA), crc)) return;
+            if (reg_TA >= MEMORY_SIZE) return;
+            if (hub->send(&memory[reg_TA], MEMORY_SIZE - uint8_t(reg_TA), crc)) return;
             break; // send 1s when read is complete, is passive, so do nothing here
 
         default: hub->raiseDeviceError(cmd);
@@ -160,8 +160,8 @@ bool DS2431::writeMemory(const uint8_t *const source, const uint8_t length, cons
 bool DS2431::readMemory(uint8_t *const destination, const uint16_t length,
                         const uint16_t position) const
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(destination, &memory[position], _length);
     return (_length == length);
 }

--- a/src/DS2431.h
+++ b/src/DS2431.h
@@ -11,10 +11,10 @@
 class DS2431 : public OneWireItem
 {
 private:
-    static constexpr uint8_t MEM_SIZE{144};
+    static constexpr uint8_t MEMORY_SIZE{144};
 
     static constexpr uint8_t PAGE_SIZE{32};
-    static constexpr uint8_t PAGE_COUNT{MEM_SIZE / PAGE_SIZE};
+    static constexpr uint8_t PAGE_COUNT{MEMORY_SIZE / PAGE_SIZE};
     static constexpr uint8_t PAGE_MASK{0b00011111};
 
     static constexpr uint8_t SCRATCHPAD_SIZE{8};
@@ -28,7 +28,7 @@ private:
     static constexpr uint8_t WP_MODE{0x55}; // write protect mode
     static constexpr uint8_t EP_MODE{0xAA}; // eprom mode
 
-    uint8_t memory[MEM_SIZE];
+    uint8_t memory[MEMORY_SIZE];
 
     uint8_t scratchpad[SCRATCHPAD_SIZE];
     uint8_t page_protection;

--- a/src/DS2433.cpp
+++ b/src/DS2433.cpp
@@ -98,7 +98,7 @@ void DS2433::duty(OneWireHub *const hub)
 
             if (hub->recv(reinterpret_cast<uint8_t *>(&reg_TA), 2)) return;
 
-            for (uint16_t i = reg_TA; i < MEM_SIZE;
+            for (uint16_t i = reg_TA; i < MEMORY_SIZE;
                  i += PAGE_SIZE) // model of the 32byte scratchpad
             {
                 if (hub->send(&memory[i], PAGE_SIZE)) return;
@@ -109,15 +109,15 @@ void DS2433::duty(OneWireHub *const hub)
     }
 }
 
-void DS2433::clearMemory(void) { memset(memory, static_cast<uint8_t>(0x00), MEM_SIZE); }
+void DS2433::clearMemory(void) { memset(memory, static_cast<uint8_t>(0x00), MEMORY_SIZE); }
 
 void DS2433::clearScratchpad(void) { memset(scratchpad, static_cast<uint8_t>(0x00), PAGE_SIZE); }
 
 bool DS2433::writeMemory(const uint8_t *const source, const uint16_t length,
                          const uint16_t position)
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(&memory[position], source, _length);
     return true;
 }
@@ -125,8 +125,8 @@ bool DS2433::writeMemory(const uint8_t *const source, const uint16_t length,
 bool DS2433::readMemory(uint8_t *const destination, const uint16_t length,
                         const uint16_t position) const
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(destination, &memory[position], _length);
     return (_length == length);
 }

--- a/src/DS2433.h
+++ b/src/DS2433.h
@@ -10,11 +10,11 @@
 class DS2433 : public OneWireItem
 {
 private:
-    static constexpr uint16_t MEM_SIZE{512};
+    static constexpr uint16_t MEMORY_SIZE{512};
     static constexpr uint16_t MEM_MASK{0x01FF};
 
     static constexpr uint8_t  PAGE_SIZE{32};
-    static constexpr uint16_t PAGE_COUNT{MEM_SIZE / PAGE_SIZE};
+    static constexpr uint16_t PAGE_COUNT{MEMORY_SIZE / PAGE_SIZE};
     static constexpr uint8_t  PAGE_MASK{0b00011111};
 
     static constexpr uint8_t REG_ES_PF_MASK{0b00100000};   // partial byte flag
@@ -22,7 +22,7 @@ private:
     static constexpr uint8_t REG_ES_AA_MASK{
             0b10000000}; // authorization accepted (data copied to target memory)
 
-    uint8_t memory[MEM_SIZE]; // 4kbit max storage
+    uint8_t memory[MEMORY_SIZE]; // 4kbit max storage
     uint8_t scratchpad[PAGE_SIZE];
 
     void clearScratchpad(void);

--- a/src/DS2434.cpp
+++ b/src/DS2434.cpp
@@ -137,7 +137,7 @@ void DS2434::duty(OneWireHub *const hub)
     }
 }
 
-void DS2434::clearMemory(void) { memset(memory, static_cast<uint8_t>(0xFF), MEM_SIZE); }
+void DS2434::clearMemory(void) { memset(memory, static_cast<uint8_t>(0xFF), MEMORY_SIZE); }
 
 void DS2434::clearScratchpad(void)
 {
@@ -147,8 +147,8 @@ void DS2434::clearScratchpad(void)
 bool DS2434::writeMemory(const uint8_t *const source, const uint16_t length,
                          const uint16_t position)
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(&memory[position], source, _length);
     return true;
 }
@@ -156,8 +156,8 @@ bool DS2434::writeMemory(const uint8_t *const source, const uint16_t length,
 bool DS2434::readMemory(uint8_t *const destination, const uint16_t length,
                         const uint16_t position) const
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(destination, &memory[position], _length);
     return (_length == length);
 }

--- a/src/DS2434.h
+++ b/src/DS2434.h
@@ -48,7 +48,7 @@ private:
     static constexpr uint8_t PAGE_SIZE{32};
     static constexpr uint8_t PAGE_COUNT{5};
 
-    static constexpr uint8_t MEM_SIZE{4 * PAGE_SIZE +
+    static constexpr uint8_t MEMORY_SIZE{4 * PAGE_SIZE +
                                       4}; // Limit the memory size to the working space
     static constexpr uint8_t SCRATCHPAD_SIZE{3 * PAGE_SIZE}; // Scratchpad is used for first 3 pages
 
@@ -58,7 +58,7 @@ private:
     uint32_t                  timer_nvwr   = 0u;
     bool                      request_temp = false;
 
-    uint8_t memory[MEM_SIZE];
+    uint8_t memory[MEMORY_SIZE];
     uint8_t scratchpad[SCRATCHPAD_SIZE];
 
     void clearScratchpad(void);

--- a/src/DS2438.cpp
+++ b/src/DS2438.cpp
@@ -94,8 +94,8 @@ void DS2438::clearMemory(void)
 
 bool DS2438::writeMemory(const uint8_t *const source, const uint8_t length, const uint8_t position)
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(&memory[position], source, _length);
 
     const uint8_t page_start = uint8_t(position >> 3);
@@ -113,8 +113,8 @@ bool DS2438::writeMemory(const uint8_t *const source, const uint8_t length, cons
 bool DS2438::readMemory(uint8_t *const destination, const uint8_t length,
                         const uint8_t position) const
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(destination, &memory[position], _length);
     return (_length == length);
 }

--- a/src/DS2438.h
+++ b/src/DS2438.h
@@ -48,7 +48,7 @@ private:
             8}; // how much of the real 8 pages should be emulated, use at least 1, max 8
     static constexpr uint8_t PAGE_SIZE{8}; //
 
-    static constexpr uint8_t MEM_SIZE{PAGE_COUNT * PAGE_SIZE};
+    static constexpr uint8_t MEMORY_SIZE{PAGE_COUNT * PAGE_SIZE};
 
     // Register Addresses
     static constexpr uint8_t REG0_MASK_IAD{0x01}; // enable automatic current measurements
@@ -60,7 +60,7 @@ private:
     static constexpr uint8_t REG0_MASK_ADB{0x40}; // adc busy flag
 
     uint8_t memory
-            [MEM_SIZE]; // this mem is the "scratchpad" in the datasheet., no EEPROM implemented
+            [MEMORY_SIZE]; // this mem is the "scratchpad" in the datasheet., no EEPROM implemented
     uint8_t crc
             [PAGE_COUNT +
              1]; // keep the matching crc for each memory-page, reading can be very time-sensitive

--- a/src/DS2450.cpp
+++ b/src/DS2450.cpp
@@ -20,7 +20,7 @@ void DS2450::duty(OneWireHub *const hub)
     {
         case 0xAA: // READ MEMORY
 
-            while (reg_TA < MEM_SIZE)
+            while (reg_TA < MEMORY_SIZE)
             {
                 const uint8_t length = PAGE_SIZE - (uint8_t(reg_TA) & PAGE_MASK);
                 if (hub->send(&memory[reg_TA], length, crc)) return;
@@ -36,7 +36,7 @@ void DS2450::duty(OneWireHub *const hub)
 
         case 0x55: // write memory (only page 1&2 allowed)
 
-            while (reg_TA < MEM_SIZE)
+            while (reg_TA < MEMORY_SIZE)
             {
                 uint8_t data;
                 if (hub->recv(&data, 1, crc)) break;
@@ -71,7 +71,7 @@ void DS2450::duty(OneWireHub *const hub)
 void DS2450::clearMemory(void)
 {
     constexpr uint8_t value_x00 = 0;
-    memset(memory, value_x00, MEM_SIZE);
+    memset(memory, value_x00, MEMORY_SIZE);
 
     // set power on defaults
     for (uint8_t adc = 0; adc < POTI_COUNT; ++adc)

--- a/src/DS2450.h
+++ b/src/DS2450.h
@@ -15,9 +15,9 @@ private:
     static constexpr uint8_t PAGE_SIZE{2 * POTI_COUNT};
     static constexpr uint8_t PAGE_MASK{0b00000111};
 
-    static constexpr uint8_t MEM_SIZE{PAGE_COUNT * PAGE_SIZE};
+    static constexpr uint8_t MEMORY_SIZE{PAGE_COUNT * PAGE_SIZE};
 
-    uint8_t memory[MEM_SIZE];
+    uint8_t memory[MEMORY_SIZE];
     // Page1 : conversion results:  16 bit for Channel A, B, C & D, power on default: 0x00
     // Page2 : control / status:    16 bit per channel
     // Page3 : alarm settings:      16 bit per channel

--- a/src/DS2502.cpp
+++ b/src/DS2502.cpp
@@ -4,7 +4,7 @@ DS2502::DS2502(uint8_t ID1, uint8_t ID2, uint8_t ID3, uint8_t ID4, uint8_t ID5, 
                uint8_t ID7)
     : OneWireItem(ID1, ID2, ID3, ID4, ID5, ID6, ID7)
 {
-    static_assert(MEM_SIZE < 256, "Implementation does not cover the whole address-space");
+    static_assert(MEMORY_SIZE < 256, "Implementation does not cover the whole address-space");
 
     clearMemory();
     clearStatus();
@@ -142,7 +142,7 @@ uint8_t DS2502::translateRedirection(const uint8_t source_address) const
     return destin_address;
 }
 
-void DS2502::clearMemory(void) { memset(memory, static_cast<uint8_t>(0xFF), MEM_SIZE); }
+void DS2502::clearMemory(void) { memset(memory, static_cast<uint8_t>(0xFF), MEMORY_SIZE); }
 
 void DS2502::clearStatus(void)
 {
@@ -152,8 +152,8 @@ void DS2502::clearStatus(void)
 
 bool DS2502::writeMemory(const uint8_t *const source, const uint8_t length, const uint8_t position)
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(&memory[position], source, _length);
 
     const uint8_t page_start = static_cast<uint8_t>(position >> 5);
@@ -166,8 +166,8 @@ bool DS2502::writeMemory(const uint8_t *const source, const uint8_t length, cons
 bool DS2502::readMemory(uint8_t *const destination, const uint8_t length,
                         const uint8_t position) const
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(destination, &memory[position], _length);
     return (_length == length);
 }

--- a/src/DS2502.h
+++ b/src/DS2502.h
@@ -14,8 +14,8 @@ private:
     static constexpr uint8_t PAGE_SIZE{32}; // bytes
     static constexpr uint8_t PAGE_MASK{PAGE_SIZE - 1};
 
-    static constexpr uint8_t  MEM_SIZE{PAGE_COUNT * PAGE_SIZE}; // bytes
-    static constexpr uint16_t MEM_MASK{MEM_SIZE - 1};
+    static constexpr uint8_t  MEMORY_SIZE{PAGE_COUNT * PAGE_SIZE}; // bytes
+    static constexpr uint16_t MEM_MASK{MEMORY_SIZE - 1};
 
     static constexpr uint8_t STATUS_SIZE{8};
 
@@ -25,7 +25,7 @@ private:
     static constexpr uint8_t STATUS_UNDEF_B1{0x05}; // 2 byte -> reserved / undefined
     static constexpr uint8_t STATUS_FACTORYP{0x07}; // 2 byte -> factoryprogrammed 0x00
 
-    uint8_t memory[MEM_SIZE];    // 4 pages of 32 bytes
+    uint8_t memory[MEMORY_SIZE];    // 4 pages of 32 bytes
     uint8_t status[STATUS_SIZE]; // eprom status bytes:
     uint8_t sizeof_memory;       // device specific "real" size
 

--- a/src/DS2506.cpp
+++ b/src/DS2506.cpp
@@ -50,7 +50,7 @@ void DS2506::duty(OneWireHub *const hub)
                 const uint16_t destin_TA = translateRedirection(reg_TA);
                 const uint8_t  length    = PAGE_SIZE - uint8_t(reg_TA & PAGE_MASK);
 
-                if (destin_TA < MEM_SIZE)
+                if (destin_TA < MEMORY_SIZE)
                 {
                     if (hub->send(&memory[destin_TA], length, crc)) return;
                 }
@@ -85,7 +85,7 @@ void DS2506::duty(OneWireHub *const hub)
                 const uint16_t destin_TA = translateRedirection(reg_TA);
                 const uint8_t  length    = PAGE_SIZE - uint8_t(reg_TA & PAGE_MASK);
 
-                if (destin_TA < MEM_SIZE)
+                if (destin_TA < MEMORY_SIZE)
                 {
                     if (hub->send(&memory[destin_TA], length, crc)) return;
                 }
@@ -208,15 +208,15 @@ void DS2506::duty(OneWireHub *const hub)
     }
 }
 
-void DS2506::clearMemory(void) { memset(memory, value_xFF, MEM_SIZE); }
+void DS2506::clearMemory(void) { memset(memory, value_xFF, MEMORY_SIZE); }
 
 void DS2506::clearStatus(void) { memset(status, value_xFF, STATUS_SIZE); }
 
 bool DS2506::writeMemory(const uint8_t *const source, const uint16_t length,
                          const uint16_t position)
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(&memory[position], source, _length);
 
     const uint8_t page_start = static_cast<uint8_t>(position >> 5);
@@ -229,8 +229,8 @@ bool DS2506::writeMemory(const uint8_t *const source, const uint16_t length,
 bool DS2506::readMemory(uint8_t *const destination, const uint16_t length,
                         const uint16_t position) const
 {
-    if (position >= MEM_SIZE) return false;
-    const uint16_t _length = (position + length >= MEM_SIZE) ? (MEM_SIZE - position) : length;
+    if (position >= MEMORY_SIZE) return false;
+    const uint16_t _length = (position + length >= MEMORY_SIZE) ? (MEMORY_SIZE - position) : length;
     memcpy(destination, &memory[position], _length);
     return (_length == length);
 }

--- a/src/DS2506.h
+++ b/src/DS2506.h
@@ -15,15 +15,15 @@ class DS2506 : public OneWireItem
 private:
     // Problem: atmega has 2kb RAM, this IC offers 8kb
     // Solution: out-of-bound-memory will be constant 0xFF, same for the depending status-registers
-    static constexpr uint16_t MEM_SIZE_PROPOSE{
+    static constexpr uint16_t MEMORY_SIZE_PROPOSE{
             256}; // TUNE HERE! Give this device as much RAM as your CPU can spare
 
     static constexpr uint8_t  PAGE_SIZE{32};
-    static constexpr uint16_t PAGE_COUNT{MEM_SIZE_PROPOSE / PAGE_SIZE}; // ATM: 8
+    static constexpr uint16_t PAGE_COUNT{MEMORY_SIZE_PROPOSE / PAGE_SIZE}; // ATM: 8
     static constexpr uint8_t  PAGE_MASK{0b00011111};
 
-    static constexpr uint16_t MEM_SIZE{PAGE_COUNT * PAGE_SIZE};
-    static constexpr uint16_t MEM_MASK{MEM_SIZE - 1};
+    static constexpr uint16_t MEMORY_SIZE{PAGE_COUNT * PAGE_SIZE};
+    static constexpr uint16_t MEM_MASK{MEMORY_SIZE - 1};
 
     static constexpr uint8_t  STATUS_SEGMENT{PAGE_COUNT / 8}; // ATM: 1
     static constexpr uint16_t STATUS_SIZE{PAGE_COUNT + (3 * STATUS_SEGMENT)};
@@ -38,11 +38,11 @@ private:
             0x100}; // 256 bytes -> Redirection to page, 0xFF if valid, ones complement (xFD is page 2)
     static constexpr uint16_t STATUS_UNDEF_B2_BEG{0x200};
 
-    static_assert(MEM_SIZE > 255, "REAL MEM SIZE IS TOO SMALL");
+    static_assert(MEMORY_SIZE > 255, "REAL MEM SIZE IS TOO SMALL");
     static_assert(STATUS_SEGMENT > 0, "REAL MEM SIZE IS TOO SMALL");
-    static_assert(MEM_SIZE <= 8192, "REAL MEM SIZE IS TOO BIG, MAX IS 8291 bytes");
+    static_assert(MEMORY_SIZE <= 8192, "REAL MEM SIZE IS TOO BIG, MAX IS 8291 bytes");
 
-    uint8_t memory[MEM_SIZE];    // at least 4 pages of 32 bytes
+    uint8_t memory[MEMORY_SIZE];    // at least 4 pages of 32 bytes
     uint8_t status[STATUS_SIZE]; // eprom status bytes
 
     uint16_t sizeof_memory;              // device specific "real" size


### PR DESCRIPTION
I encountered a compilation problem, an error occurs related to the conflict of the constant MEM_SIZE in the library and MEM_SIZE in the ESP32 itself! I decided that I can change MEM_SIZE to MEMORY_SIZE everywhere and this will not affect the operation of the library - but the problem is fixed for all platforms!